### PR TITLE
Generate config object when initializing AppModule

### DIFF
--- a/src/common/configs/config.ts
+++ b/src/common/configs/config.ts
@@ -1,6 +1,6 @@
 import type { Config } from './config.interface';
 
-const config: Config = {
+export default (): Config => ({
   nest: {
     port: 3000,
   },
@@ -25,6 +25,4 @@ const config: Config = {
     refreshIn: '7d',
     bcryptSaltOrRound: 10,
   },
-};
-
-export default (): Config => config;
+});


### PR DESCRIPTION
## Problem

If I try to use environment value like `port: parseInt(process.env.PORT, 10) || 3000,` instead of hard coded values, current implementation doesn't get correct value from `.env`.

## Solution

I moved `config` object into function, now the config object will be generated on `ConfigModule.forRoot({ isGlobal: true, load: [config] })` and we can get values from `.env` if we want.

source: https://docs.nestjs.com/techniques/configuration#custom-configuration-files